### PR TITLE
Add Kdoc to vimkubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following has been implemented so far:
 - Delete resources
 - Switch namespace
 - Switch contexts
+- View kubernetes resource manuals 
 
 Installation
 ------------
@@ -80,6 +81,15 @@ This plugin assumes your Kubernetes cluster is reachable and logged in with [kub
   Apply file contents. When used with a selection(), applies the selected content, else applies the entire file.
   Can be used on any open buffer.
 
+- `:Kdoc {resource}`
+
+  Retrieve documentation on a specific `{resource}`.
+
+  You can also use `<Tab>` for completion and to cycle through possible resources that are manifest on your kubernetes cluster. 
+
+   > **_NOTE:_** `:Kdoc` will retrieve manuals for any CRD on the cluster. There doesn't have to be any existing k8s objects
+   on the cluster in order to retrieve the manual. 
+   
 - `:K`
 
   Run any arbitrary `kubectl` command.

--- a/autoload/vimkubectl.vim
+++ b/autoload/vimkubectl.vim
@@ -73,6 +73,16 @@ fun! vimkubectl#editResourceObject(args) abort
   call vimkubectl#buf#edit_load('split', l:resource[0], l:resource[1])
 endfun
 
+" :Kdoc
+" Open a buffer with the resource manual loaded
+" Args need to be in `res` or `res.spec` format. 
+" Args directly supplied to kubectl/oc explain
+fun! vimkubectl#viewResourceDoc(args) abort
+  const resourceSpec = a:args
+  call vimkubectl#buf#doc_load('split', l:resourceSpec)
+endfun
+
+" This one is determining if user is doing a Kedit or Kget
 fun! vimkubectl#hijackBuffer() abort
   const resource = substitute(expand('%'), '^kube://', '', '')
   const parsedResource = split(l:resource, '/')
@@ -81,6 +91,10 @@ fun! vimkubectl#hijackBuffer() abort
   else
     call vimkubectl#buf#edit_prepare()
   endif
+endfun
+
+fun! vimkubectl#hijackDocBuffer() abort
+  call vimkubectl#buf#doc_prepare()
 endfun
 
 fun! vimkubectl#cleanupBuffer(buf) abort

--- a/autoload/vimkubectl/kube.vim
+++ b/autoload/vimkubectl/kube.vim
@@ -155,6 +155,25 @@ fun! vimkubectl#kube#fetchResourceListLoop(
         \ )
 endfun
 
+" Fetch doc
+" returns doc
+fun! vimkubectl#kube#fetchDoc(
+      \ resourceSpec,
+      \ namespace,
+      \ callback,
+      \ ctx = {}
+      \ ) abort
+  const cmd = s:craftCmd(join(['explain', a:resourceSpec ]), a:namespace)
+  return vimkubectl#util#asyncRun(
+        \ s:asyncCmd(l:cmd),
+        \ a:callback,
+        \ 'array',
+        \ a:ctx
+        \ )
+endfun
+
+
+
 " Runs arbitrary command
 fun! vimkubectl#kube#runCmd(cmd, callback) abort
   const cmd = s:craftCmd(a:cmd)

--- a/doc/vimkubectl.txt
+++ b/doc/vimkubectl.txt
@@ -45,6 +45,10 @@ COMMANDS                                        *vimkubectl-commands*
 			applies the entire file.
 			Can be used on any open buffer.
 
+:Kdoc {resource}                                *:Kdoc*
+			Open a split that displays the manual for any Custom 
+			Resource Definition on the cluster. 
+
 :K                                              *:K*
 			Run any arbitrary `kubectl` command.
 

--- a/plugin/vimkubectl.vim
+++ b/plugin/vimkubectl.vim
@@ -7,6 +7,7 @@ command -bar -bang -complete=custom,vimkubectl#allResources -nargs=? Kget call v
 command -bar -bang -complete=custom,vimkubectl#allNamespaces -nargs=? Kns call vimkubectl#switchOrShowNamespace(<q-args>)
 command -bar -bang -complete=custom,vimkubectl#allContexts -nargs=? Kctx call vimkubectl#switchOrShowContext(<q-args>)
 command -bar -bang -complete=custom,vimkubectl#allResourcesAndObjects -nargs=+ Kedit call vimkubectl#editResourceObject(<q-args>)
+command -bar -bang -complete=custom,vimkubectl#allResources -nargs=+ Kdoc call vimkubectl#viewResourceDoc(<q-args>)
 command -bar -bang -nargs=0 -range=% Kapply <line1>,<line2>call vimkubectl#buf#applyActiveBuffer()
 command -bar -nargs=+ K call vimkubectl#runCmd(<q-args>)
 
@@ -14,6 +15,8 @@ augroup vimkubectl_internal
   autocmd! *
   autocmd BufReadCmd kube://* nested call vimkubectl#hijackBuffer()
   autocmd BufDelete kube://* nested call vimkubectl#cleanupBuffer(expand('<abuf>'))
+  autocmd BufReadCmd kubeDoc://* nested call vimkubectl#hijackDocBuffer()
+  autocmd BufDelete kubeDoc://* nested call vimkubectl#cleanupBuffer(expand('<abuf>'))
 augroup END
 
 " vim: et:sw=2:sts=2:


### PR DESCRIPTION
Kdoc uses the same autocompletion features as Kget and Kedit to open a buffer with the kubernetes manual for a specific resourceType/CRD.

This prevents context switching for kube admins
and allows you to be editing k8s objects while
simultaneously having the corresponding k8s manual in the same window.

You can read k8s manuals with kdoc like:
:Kdoc node
:Kdoc nodes
:Kdoc nodes.spec
etc..

Ideas for future improvements to Kdoc include:
*Autocompletion for specs like:
  :Kdoc n{TAB}odes.sp{TAB}ec.ta{TAB}ints
*Navigate kubeDoc buffer with keys like 'ff'.
  Open docs for nodes.spec and type 'ff' over taints to
  refresh the buffer to :Kdoc nodes.spec.taints
*Navigate to the parent spec with keys like 'ee'
  Open nodes.spec.taints and then go back to nodes.spec
  with 'ee'